### PR TITLE
Added a default screensize of 1280x1024x24 for xvfb

### DIFF
--- a/protractor.sh
+++ b/protractor.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-xvfb-run protractor $@
+xvfb-run --server-args='-screen 0 1280x1024x24' protractor $@
 


### PR DESCRIPTION
By default xvfb runs with a screensize of 640x480x8. Because responsive websites handle differently at different screensizes (possibly not rendering navigation elements the same way), I added a bigger screen that is used by default. 
