### PR TITLE
chore(travis) add travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: trusty
+sudo: required
+language: node_js
+node_js:
+  - '6'
+
+services: docker
+
+before_install:
+  - npm install -g grunt yarn@0.17.9
+
+install:
+  - git clone https://github.com/angular/angular.js.git ~/angular.js
+  - cd ~/angular.js
+  - git checkout v1.6.1
+  - yarn install
+  - grunt
+  - grunt connect &
+
+before_script:
+  - image="protractor-headless"
+
+script:
+  - >
+    cd $TRAVIS_BUILD_DIR &&
+    docker build -t "$image" . &&
+    cd ~/angular.js &&
+    docker run --privileged -it --rm --net=host -v /dev/shm:/dev/shm -v $(pwd):/protractor $image protractor-conf.js


### PR DESCRIPTION
Add travis config for testing image build and an example run of protractor-headless, on Angular 1.6.1