### PR TITLE
feat(node_modules) add node_modules from current dir to NODE_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ node_js:
 services: docker
 
 before_install:
-  - npm install -g grunt yarn@0.21.3
+  - npm install -g grunt yarn@0.17.9
 
 install:
   - git clone https://github.com/angular/angular.js.git ~/angular.js
   - cd ~/angular.js
-  - git checkout v1.6.4
+  - git checkout v1.6.1
   - yarn install
   - grunt
   - grunt connect &

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:6.9.4-slim
 MAINTAINER j.ciolek@webnicer.com
 WORKDIR /tmp
 COPY webdriver-versions.js ./
-ENV CHROME_PACKAGE="google-chrome-stable_57.0.2987.98-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules
-RUN npm install -g protractor@4.0.14 mocha@3.4.2 jasmine@2.7.0 minimist@1.2.0 && \
+ENV CHROME_PACKAGE="google-chrome-stable_57.0.2987.98-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules:/protractor/node_modules
+RUN npm install -g protractor@4.0.14 minimist@1.2.0 && \
     node ./webdriver-versions.js --chromedriver 2.29 && \
     webdriver-manager update && \
     echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ The image in the latest version contains the following packages in their respect
 
 * Chrome - 57
 * Protractor - 4.0.14
-* Jasmine - 2.7.0
-* Mocha - 3.4.2
 * Node.js - 6.9.4
 * Chromedriver - 2.29
 
 The packages are pinned to those versions so that and they should work together without issues. Pulling in the latest version of Chrome during image build proved unsuccessful at times, because Chromedriver is usually lagging behind with support.
+
+**IMPORTANT CHANGE**
+
+Starting with Chrome 57 Jasmine and Mocha are no longer included, assuming the packages are installed in the project's directory. Therefore the image uses `node_modules` subdirectory from the `/protractor` directory mounted when running the image (see Usage below).
 
 # Usage
 
@@ -52,6 +54,7 @@ The script will allow you to run dockerised protractor like so:
 protractor-headless [protractor options]
 ```
 
+The image adds `/protractor/node_modules` directory to its `NODE_PATH` environmental variable, so that it can use Jasmine, Mocha or whatever else the project uses from the project's own node modules. Therefore Mocha and Jasmine are no longer included in the image.
 
 ## Setting up custom screen resolution
 
@@ -83,4 +86,4 @@ This options is required **only** if the dockerised Protractor is run against lo
 The tests are run on Travis and include the following:
 
 * image build
-* run of protractor-headless against angular.js v1.6.4
+* run of protractor-headless against angular.js v1.6.1


### PR DESCRIPTION
This way the image doesn't have to have mocha, jasmin, karma, etc.

Also, bring back Angular 1.6.1 for the test purposes.