### PR TITLE
Upgrade to Chrome58

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ node_js:
 services: docker
 
 before_install:
-  - npm install -g grunt yarn@0.21.3
+  - npm install -g grunt yarn@0.17.9
 
 install:
   - git clone https://github.com/angular/angular.js.git ~/angular.js
   - cd ~/angular.js
-  - git checkout v1.6.4
+  - git checkout v1.6.1
   - yarn install
   - grunt
   - grunt connect &

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ node_js:
 services: docker
 
 before_install:
-  - npm install -g grunt yarn@0.17.9
+  - npm install -g grunt yarn@0.21.3
 
 install:
   - git clone https://github.com/angular/angular.js.git ~/angular.js
   - cd ~/angular.js
-  - git checkout v1.6.1
+  - git checkout v1.6.4
   - yarn install
   - grunt
   - grunt connect &

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM node:6.9.4-slim
 MAINTAINER j.ciolek@webnicer.com
 WORKDIR /tmp
 COPY webdriver-versions.js ./
-ENV CHROME_PACKAGE="google-chrome-stable_56.0.2924.87-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules
-RUN npm install -g protractor@4.0.14 mocha@3.2.0 jasmine@2.5.3 minimist@1.2.0 && \
-    node ./webdriver-versions.js --chromedriver 2.27 && \
+ENV CHROME_PACKAGE="google-chrome-stable_57.0.2987.98-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules
+RUN npm install -g protractor@4.0.14 mocha@3.4.2 jasmine@2.7.0 minimist@1.2.0 && \
+    node ./webdriver-versions.js --chromedriver 2.29 && \
     webdriver-manager update && \
     echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM node:6.9.4-slim
 MAINTAINER j.ciolek@webnicer.com
 WORKDIR /tmp
 COPY webdriver-versions.js ./
-ENV CHROME_PACKAGE="google-chrome-stable_57.0.2987.98-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules:/protractor/node_modules
+ENV CHROME_PACKAGE="google-chrome-stable_58.0.3029.96-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules:/protractor/node_modules
 RUN npm install -g protractor@4.0.14 minimist@1.2.0 && \
-    node ./webdriver-versions.js --chromedriver 2.29 && \
+    node ./webdriver-versions.js --chromedriver 2.31 && \
     webdriver-manager update && \
     echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:6.9.4-slim
 MAINTAINER j.ciolek@webnicer.com
 WORKDIR /tmp
 COPY webdriver-versions.js ./
-ENV CHROME_PACKAGE="google-chrome-stable_57.0.2987.98-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules
-RUN npm install -g protractor@4.0.14 mocha@3.4.2 jasmine@2.7.0 minimist@1.2.0 && \
+ENV CHROME_PACKAGE="google-chrome-stable_57.0.2987.98-1_amd64.deb" NODE_PATH=/usr/local/lib/node_modules:/protractor/node_modules
+RUN npm install -g protractor@4.0.14 minimist@1.2.0 && \
     node ./webdriver-versions.js --chromedriver 2.29 && \
     webdriver-manager update && \
     echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \

--- a/README.md
+++ b/README.md
@@ -14,25 +14,27 @@ To be perfectly honest - it is a [real chrome running on xvfb](http://tobyho.com
 
 ## Supported tags
 
-* chrome57, latest
+* chrome58, latest
 * chrome56
 * chrome55
 * chrome54
+
+Please note that chrome57 is not available, as it does not work reliably with Ptoractor. There were intermittent test failures, usually around selecting elements `by.binding`.
 
 ## What is included in the latest?
 
 The image in the latest version contains the following packages in their respective versions:
 
-* Chrome - 57
+* Chrome - 58
 * Protractor - 4.0.14
 * Node.js - 6.9.4
-* Chromedriver - 2.29
+* Chromedriver - 2.31
 
 The packages are pinned to those versions so that and they should work together without issues. Pulling in the latest version of Chrome during image build proved unsuccessful at times, because Chromedriver is usually lagging behind with support.
 
 **IMPORTANT CHANGE**
 
-Starting with Chrome 57 Jasmine and Mocha are no longer included, assuming the packages are installed in the project's directory. Therefore the image uses `node_modules` subdirectory from the `/protractor` directory mounted when running the image (see Usage below).
+Starting with Chrome 58 Jasmine and Mocha are no longer included, assuming the packages are installed in the project's directory. Therefore the image uses `node_modules` subdirectory from the `/protractor` directory mounted when running the image (see Usage below).
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ To be perfectly honest - it is a [real chrome running on xvfb](http://tobyho.com
 
 ## Supported tags
 
-* chrome56, latest
+* chrome57, latest
+* chrome56
 * chrome55
 * chrome54
 
@@ -22,12 +23,12 @@ To be perfectly honest - it is a [real chrome running on xvfb](http://tobyho.com
 
 The image in the latest version contains the following packages in their respective versions:
 
-* Chrome - 56
+* Chrome - 57
 * Protractor - 4.0.14
-* Jasmine - 2.5.3
-* Mocha - 3.2.0
+* Jasmine - 2.7.0
+* Mocha - 3.4.2
 * Node.js - 6.9.4
-* Chromedriver - 2.27
+* Chromedriver - 2.29
 
 The packages are pinned to those versions so that and they should work together without issues. Pulling in the latest version of Chrome during image build proved unsuccessful at times, because Chromedriver is usually lagging behind with support.
 
@@ -82,4 +83,4 @@ This options is required **only** if the dockerised Protractor is run against lo
 The tests are run on Travis and include the following:
 
 * image build
-* run of protractor-headless against angular.js v1.6.1
+* run of protractor-headless against angular.js v1.6.4

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ The image in the latest version contains the following packages in their respect
 
 * Chrome - 57
 * Protractor - 4.0.14
-* Jasmine - 2.7.0
-* Mocha - 3.4.2
 * Node.js - 6.9.4
 * Chromedriver - 2.29
 
 The packages are pinned to those versions so that and they should work together without issues. Pulling in the latest version of Chrome during image build proved unsuccessful at times, because Chromedriver is usually lagging behind with support.
+
+**IMPORTANT CHANGE**
+
+Starting with Chrome 57 Jasmine and Mocha are no longer included, assuming the packages are installed in the project's directory. Therefore the image uses `node_modules` subdirectory from the `/protractor` directory mounted when running the image (see Usage below).
 
 # Usage
 
@@ -52,6 +54,7 @@ The script will allow you to run dockerised protractor like so:
 protractor-headless [protractor options]
 ```
 
+The image adds `/protractor/node_modules` directory to its `NODE_PATH` environmental variable, so that it can use Jasmine, Mocha or whatever else the project uses from the project's own node modules. Therefore Mocha and Jasmine are no longer included in the image.
 
 ## Setting up custom screen resolution
 
@@ -83,4 +86,4 @@ This options is required **only** if the dockerised Protractor is run against lo
 The tests are run on Travis and include the following:
 
 * image build
-* run of protractor-headless against angular.js v1.6.4
+* run of protractor-headless against angular.js v1.6.1

--- a/protractor.sh
+++ b/protractor.sh
@@ -9,4 +9,4 @@ useradd -m -o -u $uid -g $gid protractor
 # Therefore, we need to run it as a regular user, taking care
 # to set the uid and gid of that user to match those of the current directory owner.
 # Otherwise protractor could experience problems reading files from the current directory.
-sudo -u protractor xvfb-run --server-args="-screen 0 ${SCREEN_RES}" protractor $@
+sudo -u protractor xvfb-run --server-args="-screen 0 ${SCREEN_RES}" -a protractor $@


### PR DESCRIPTION
A few additional changes:

* The image does no longer contain Jasmine or Mocha - instead it relies on their presence in the `/protractor/node_modules` directory, when `/protractor` is the directory mounted from host.
* `xvfb-run` got flag `-a` which allows for running multiple protractor-headless images at once.